### PR TITLE
Enable clang-tidy in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,13 @@ jobs:
           esp_idf_version: v5.4.1
           target: esp32
           path: '.'
+      - name: clang-tidy
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v5.4.1
+          target: esp32
+          path: '.'
+          command: idf.py clang-check
       - name: Test with Wokwi
         uses: wokwi/wokwi-ci-action@v1
         with:

--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ The project is already set up for debugging. To debug the project, first start W
 The debugger is configured to use TCP port 3333. If this port is already in use on your computer, you can change it in the `.vscode/launch.json` file (`miDebuggerServerAddress`) and in `wokwi.toml` (`gdbServerPort`).
 
 Note that the debugger setup requires the ESP-IDF extension to be installed in VS Code. If you don't have the ESP-IDF extension, you can manually set `miDebuggerServerAddress` in `.vscode/launch.json` to point to your local installation of the `xtensa-esp32-elf-gdb` debugger (it's usually installed in the esp tools directory, under `tools/xtensa-esp-elf-gdb/<version>/xtensa-esp-elf-gdb/bin`).
+
+## Continuous Integration
+
+GitHub Actions build this project, run `clang-tidy` checks, and verify the simulation in Wokwi. These automated checks help catch code issues before changes are merged.


### PR DESCRIPTION
## Summary
- run `idf.py clang-check` during CI
- document the CI checks in README

## Testing
- `pre-commit` *(fails: command not found)*